### PR TITLE
All profile values must be in uppercase

### DIFF
--- a/pkg/input/profile/profile.go
+++ b/pkg/input/profile/profile.go
@@ -20,11 +20,11 @@ const (
 	DW Profile = "DW"
 
 	// Mixed profile
-	Mixed Profile = "Mixed"
+	Mixed Profile = "MIXED"
 
 	// Desktop is the development machine on any non-production server
 	// that needs to consume less resources than a regular server.
-	Desktop Profile = "Desktop"
+	Desktop Profile = "DESKTOP"
 )
 
 // AllProfiles Lists all profiles currently available


### PR DESCRIPTION
Because of the `string.ToUpper()` in `Set`, all strings must be in uppercase. Otherwise, it cannot recognize the value. For example, the value "Mixed" leads to an error.