### PR TITLE
feat: deploy to Dokploy on release alongside Heroku

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,19 @@ jobs:
         run: |
           curl https://cli-assets.heroku.com/install.sh | sh
           /usr/local/bin/heroku container:release web --app ${{ secrets.HEROKU_APP_NAME }}
+
+      - name: Deploy on Dokploy
+        env:
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          DOKPLOY_API_URL: ${{ secrets.DOKPLOY_API_URL }}
+          DOKPLOY_APP_ID: ${{ secrets.DOKPLOY_APP_ID }}
+        run: |
+          curl -f -X POST "${DOKPLOY_API_URL}/api/application.deploy" \
+            -H 'accept: application/json' \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            -d "{
+              \"applicationId\": \"${DOKPLOY_APP_ID}\",
+              \"title\": \"Release ${GITHUB_REF_NAME}\",
+              \"description\": \"GoReleaser tag ${GITHUB_REF_NAME}\"
+            }"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,15 @@ make clean        # Remove dist/ and generated docs
 ## CI/CD
 
 - **cover.yml**: runs `make build` and `make test`, pushes coverage to Coveralls
-- **release.yml**: triggered on tags, runs goreleaser for multi‑arch binaries and Docker images
+- **release.yml**: triggered on tags, runs goreleaser for multi‑arch binaries and Docker images, then releases to Heroku and Dokploy
+
+Release workflow secrets:
+
+| Secret | Used for |
+| --- | --- |
+| `HEROKU_EMAIL`, `HEROKU_API_KEY`, `HEROKU_APP_NAME` | Heroku Container Registry push and `container:release` |
+| `DOCKER_USERNAME`, `DOCKER_TOKEN` | Docker Hub image publish |
+| `DOKPLOY_API_URL`, `DOKPLOY_API_KEY`, `DOKPLOY_APP_ID` | Dokploy deploy after image publish (`pgconfig/api:latest`) |
 
 ## Commit Conventions
 


### PR DESCRIPTION
## Summary

- Adds a `Deploy on Dokploy` step to `release.yml` after the existing Heroku `container:release`
- Keeps the same tag-triggered GoReleaser flow; Dokploy pulls the freshly published `pgconfig/api:latest` image
- Documents the new GitHub Actions secrets in `AGENTS.md`

## Required setup (before merge)

### 1. Dokploy application

Configure the application with **Source Type: Docker** (not GitHub build):

| Field | Value |
|---|---|
| Docker Image | `pgconfig/api:latest` |
| Environment | `PORT=3000` |
| Domain port | `3000` |

### 2. GitHub repository secrets

Add in **Settings → Secrets and variables → Actions**:

| Secret | Example | Description |
|---|---|---|
| `DOKPLOY_API_URL` | `https://dokploy.example.com` | Base URL, no trailing slash |
| `DOKPLOY_API_KEY` | `dkp_live_...` | API key from Dokploy profile |
| `DOKPLOY_APP_ID` | `cm5r8k9p00001xyz` | Application ID from Dokploy |

To find the application ID:

```bash
curl -s 'https://dokploy.example.com/api/project.all' \
  -H 'x-api-key: YOUR_KEY' | jq
```

## Release flow after merge

```
git tag vX.Y.Z && git push origin vX.Y.Z
  → GoReleaser builds and pushes images
  → Heroku container:release web
  → Dokploy application.deploy (pulls pgconfig/api:latest)
```

## Test plan

- [ ] Add the three Dokploy secrets to the repository
- [ ] Confirm Dokploy app uses Docker source with `pgconfig/api:latest`
- [ ] Create a test tag and verify both Heroku and Dokploy deploy succeed
- [ ] Hit `/v1/tuning/list-environments` on both endpoints